### PR TITLE
Add google site verification

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -77,6 +77,9 @@ color_scheme: dark
 ga_tracking: G-8FNXG696PB
 ga_tracking_anonymize_ip: true # Use GDPR compliant Google Analytics settings (true by default)
 
+# Google Site Verification (meta tag)
+site_verification_token: "4SG_2KfCa2XVgO0fu6cjWwpp63M1in1SLQUBAXW0d3I"
+
 collections:
     # Define a collection named "docs", its documents reside in the "_docs" directory
     docs:

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -1,0 +1,44 @@
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+
+  {% if site.site_verification_token != nil %}
+  <meta name="google-site-verification" content="{{ site.site_verification_token }}" />
+  {% endif %}
+
+  {% unless site.plugins contains "jekyll-seo-tag" %}
+    <title>{{ page.title }} - {{ site.title }}</title>
+
+    {% if page.description %}
+      <meta name="Description" content="{{ page.description }}">
+    {% endif %}
+  {% endunless %}
+
+  <link rel="shortcut icon" href="{{ 'favicon.ico' | relative_url }}" type="image/x-icon">
+
+  <link rel="stylesheet" href="{{ '/assets/css/just-the-docs-default.css' | relative_url }}">
+
+  {% if site.ga_tracking != nil %}
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.ga_tracking }}"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', '{{ site.ga_tracking }}'{% unless site.ga_tracking_anonymize_ip == nil %}, { 'anonymize_ip': true }{% endunless %});
+    </script>
+
+  {% endif %}
+
+  {% if site.search_enabled != false %}
+    <script type="text/javascript" src="{{ '/assets/js/vendor/lunr.min.js' | relative_url }}"></script>
+  {% endif %}
+  <script type="text/javascript" src="{{ '/assets/js/just-the-docs.js' | relative_url }}"></script>
+
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  {% seo %}
+
+  {% include head_custom.html %}
+
+</head>


### PR DESCRIPTION
Add the following meta tag to the head of every page. The content comes from the `site_verification_token` in the config.

```
<meta name="google-site-verification" content="CONTENT_FROM_GOOGLE" />
```

